### PR TITLE
flactag syntax improvement & error-proofing, readme edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,6 @@ Arguments:
 - audio: path to the flac file that will have its metadata changed
 - image: path of the image to be assigned to the flac, can be both jpg and png, in any acpect rato.
   
-Note: Provided with both filepaths, the script will change both text and image metadata.
-Given only the flac filepath, only text tags will be modified.
-
 ## Disclaimer
 I do not condone the usage of any of those tools for illicit purposes. Please use the provided tools (especially flacrip) only for your own, personal use.
 Content piracy and redistribution may be punishable by law, consult your local authorities for more information.

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ Tool for metadata addition or edition for flac files, automatically naming the f
 >[Artist] - [Title].flac
 
 Usage:
-> flactag [image] [image]
+> flactag [audio] [image]
 
 Arguments:
-- flac location: path to the audio file that will have its metadata changed
-- image location: path of the image to be assigned to the flac, can be both jpg and png, in any acpect rato.
+- audio: path to the flac file that will have its metadata changed
+- image: path of the image to be assigned to the flac, can be both jpg and png, in any acpect rato.
   
 Note: Provided with both filepaths, the script will change both text and image metadata.
 Given only the flac filepath, only text tags will be modified.

--- a/audiotoolbox.sh
+++ b/audiotoolbox.sh
@@ -4,24 +4,30 @@
 #from superuser.com, modified to fit digital capture. 
 
 flacrip(){
+
 	artist="${1:-Unknown}"
 	title="${2:-Unknown}"
 	album="${3:-Unknown}"
 	filename="$artist - $title.flac"
+
 	echo -e "\e[1;36mPlease select a capture device:\e[0m"
 	pactl list sources short
 	read deviceId;
+
 	echo -e "\e[1;33mPreparing to rip:\n$filename"
 	echo -e "\e[1;31m[!] Press Q to end capturing [!]\e[0m"
 	echo -e "\e[1;36mPlease wait...\e[0m"
+
 	pactl unload-module module-suspend-on-idle
 	sleep 1
 	ffmpeg -hide_banner -f pulse -ar 44100 -sample_fmt s16 -i $deviceId "temp.wav"
 	pactl load-module module-suspend-on-idle	
 	ffmpeg -hide_banner -i "temp.wav"\
+
 	-af silenceremove=start_periods=1:start_silence=0.1:start_threshold=0,areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0,areverse\
 	-metadata title="$title" -metadata artist="$artist" -metadata album="$album" -metadata album_artist="$artist" -sample_fmt s16 "$filename"
 	rm temp.wav
+	
 	echo -e "\e[1;32mRip complete! Saved file:\e[0m\n\e[1;33m$filename\e[0m"
 }
 
@@ -40,52 +46,78 @@ audioclip(){
 flacer(){
 	ffmpeg -hide_banner -i "$1" -c:a flac -af aformat=s16:44100 "${1%.*}.flac"
 	if [[ -f $NAME.flac ]]; then
-	echo -e "\e[1;33mConversion complete: "${1%.*}.flac" in $PWD\e[0m"
+		echo -e "\e[1;33mConversion complete: "${1%.*}.flac" in $PWD\e[0m"
 	fi
 }
 
 flactag(){
+	
 	filePath="${1:-Unknown}"
-	if [[ -f "$filePath" ]]; then
-	if [[ $filePath == *.flac ]]; then
 	picturePath="${2:-Unknown}"
+
+
+	if ! [[ -f $filePath ]]; then
+		echo -e "\e[1;31mGiven file does not exist!\e[0m"
+		return 0
+	fi
+
+	if ! [[ $filePath == *.flac ]]; then
+		echo -e "\e[1;31mWrong audio file format!\e[0m"
+		return 0
+	fi
+
+	if [ -z "$2" ]; then
+		echo -e "\e[1;31mImage file not provided!\e[0m"
+		return 0
+	fi
+
+	if ! [[ -f $picturePath ]]; then
+		echo -e "\e[1;31mImage file does not exist!\e[0m"
+		return 0
+	fi
+
+	if ! ([[ $picturePath == *.png ]] || [[ $picturePath == *.jpg ]] || [[ $picturePath == *.jpeg ]]); then
+		echo -e "\e[1;31mWrong image file format!\e[0m"
+		return 0
+	fi
+
+
 	ffprobe -hide_banner "$filePath"
 	while true; do
-	echo -e "\e[1;33mDo you want to remove this metadata? [y/N] \e[0m"
-	read opt
-	case $opt in
-	y|Y|"")
-	echo -e "\e[1;33mRemoving old metadata...\e[0m"
-	metaflac --remove-all "$filePath"
-	echo -e "\e[1;33mSet new tags:\e[0m"
-	echo -e "Artist:"
-	read artist
-	echo -e "Title:"
-	read title
-	echo -e "Album:"
-	read album
-	metaflac --set-tag ARTIST="$artist" "$filePath"
-	metaflac --set-tag=TITLE="$title" "$filePath"
-	metaflac --set-tag=ALBUM="$album" "$filePath"
-	mv "$filePath" "./$artist - $title.flac"
-	if ! [ -z "$2" ]; then
-	if test -f "$picturePath"; then
-	metaflac --import-picture-from="$picturePath" "./$artist - $title.flac"
-	else
-	echo -e "\e[1;31mGiven image file does not exsist!\e[0m"
-	fi
-	fi
-	echo -e "\e[1;32mNew tags set! Saved file:\e[0m\n\e[1;33m$artist - $title.flac\e[0m"
-	return 0 ;;
-	n|N)
-	echo -e "Aborting" 
-	return 0 ;;
+
+		echo -e "\e[1;33mDo you want to remove this metadata? [y/n] \e[0m"
+		read opt
+
+		case $opt in
+		y|Y|"")
+			echo -e "\e[1;33mRemoving old metadata...\e[0m"
+			metaflac --remove-all "$filePath"
+
+			echo -e "\e[1;33mSet new tags:\e[0m"
+			echo -e "Artist:"
+			read artist
+			echo -e "Title:"
+			read title
+			echo -e "Album:"
+			read album
+
+			metaflac --set-tag ARTIST="$artist" "$filePath"
+			metaflac --set-tag=TITLE="$title" "$filePath"
+			metaflac --set-tag=ALBUM="$album" "$filePath"
+			mv "$filePath" "./$artist - $title.flac"
+
+			metaflac --import-picture-from="$picturePath" "./$artist - $title.flac"
+
+			echo -e "\e[1;32mNew tags set! Saved file:\e[0m\n\e[1;33m$artist - $title.flac\e[0m"
+			return 0 ;;
+			
+		n|N)
+			echo -e "\e[1;33mAborting...\e[0m" 
+			return 0 ;;
+
+		*)
+			echo -e "\e[1;31mInvalid option!\e[0m"
+
 	esac
 	done
-	else
-	echo -e "\e[1;31mWrong format!\e[0m"
-	fi
-	else
-	echo -e "\e[1;31mFile doesn't exist!\e[0m"
-	fi
 }

--- a/audiotoolbox.sh
+++ b/audiotoolbox.sh
@@ -4,30 +4,24 @@
 #from superuser.com, modified to fit digital capture. 
 
 flacrip(){
-
 	artist="${1:-Unknown}"
 	title="${2:-Unknown}"
 	album="${3:-Unknown}"
 	filename="$artist - $title.flac"
-
 	echo -e "\e[1;36mPlease select a capture device:\e[0m"
 	pactl list sources short
 	read deviceId;
-
 	echo -e "\e[1;33mPreparing to rip:\n$filename"
 	echo -e "\e[1;31m[!] Press Q to end capturing [!]\e[0m"
 	echo -e "\e[1;36mPlease wait...\e[0m"
-
 	pactl unload-module module-suspend-on-idle
 	sleep 1
 	ffmpeg -hide_banner -f pulse -ar 44100 -sample_fmt s16 -i $deviceId "temp.wav"
 	pactl load-module module-suspend-on-idle	
 	ffmpeg -hide_banner -i "temp.wav"\
-
 	-af silenceremove=start_periods=1:start_silence=0.1:start_threshold=0,areverse,silenceremove=start_periods=1:start_silence=0.1:start_threshold=0,areverse\
 	-metadata title="$title" -metadata artist="$artist" -metadata album="$album" -metadata album_artist="$artist" -sample_fmt s16 "$filename"
 	rm temp.wav
-	
 	echo -e "\e[1;32mRip complete! Saved file:\e[0m\n\e[1;33m$filename\e[0m"
 }
 

--- a/audiotoolbox.sh
+++ b/audiotoolbox.sh
@@ -66,7 +66,7 @@ flactag(){
 		return 0
 	fi
 
-	if [ -z "$2" ]; then
+	if [ -z $2 ]; then
 		echo -e "\e[1;31mImage file not provided!\e[0m"
 		return 0
 	fi


### PR DESCRIPTION
### README.md
- Simple clarifications
- Deletion of a redundant comment (by changes in audiotoolbox.sh image now has to be provided)

### audiotoolbox.sh
- Improved syntax for better readability
- Error-proofing at the very beginning of the flactag function execution
